### PR TITLE
Small fix

### DIFF
--- a/articles/graphql/schema-design/README.md
+++ b/articles/graphql/schema-design/README.md
@@ -900,7 +900,7 @@ type Mutation {
 
 ```diff
 type CreatePersonPayload {
-+  recordId: ID!
++  recordId: ID
 +  record: Person
   # ... любые другие поля, которые пожелаете
 }


### PR DESCRIPTION
Во избежание противоречий, в соответствии с пунктом "6.6", сделал возвращаемый `recordId` nullable.